### PR TITLE
Improve syntax highlighting

### DIFF
--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -205,7 +205,8 @@
 ; Built in identifiers:
 ; alone these are marked as keywords
 [
-  "deferred"
+ (part_of_builtin)
+ "deferred"
  "factory"
  "get"
  "implements"

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -139,6 +139,16 @@
   . (selector (argument_part (arguments)))
 )
 
+; Some methods do not have a selector as a parent of the conditional_assignable_selector
+; For example, super methods.
+((unconditional_assignable_selector (identifier) @function.method)
+  . (selector (argument_part (arguments)))
+)
+
+((conditional_assignable_selector (identifier) @function.method)
+  . (selector (argument_part (arguments)))
+)
+
 ; assignments
 (assignment_expression
  left: (assignable_expression) @variable)

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -108,6 +108,10 @@
 ((identifier) @type
  (#match? @type "^_?[A-Z].*[a-z]"))
 
+(local_variable_declaration
+    (initialized_variable_definition
+        name: (identifier) @variable))
+
 ; properties
 (unconditional_assignable_selector
  (identifier) @property)

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -89,7 +89,6 @@
  name: (identifier) @type)
 (enum_constant
  name: (identifier) @type)
-(void_type) @type
 
 ((scoped_identifier
   scope: (identifier) @type
@@ -169,6 +168,7 @@
 ; Reserved words (cannot be used as identifiers)
 [
   (case_builtin)
+  (void_type)
  "late"
  "required"
  "extension"

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -115,6 +115,8 @@
     body: (function_expression_body
         (identifier) @variable))
 
+(catch_parameters (identifier) @variable)
+
 ; properties
 (unconditional_assignable_selector
  (identifier) @property)

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -117,7 +117,12 @@
 
 ((selector
   (unconditional_assignable_selector (identifier) @function.method))
-  (selector (argument_part (arguments)))
+  . (selector (argument_part (arguments)))
+)
+
+((selector
+  (conditional_assignable_selector (identifier) @function.method))
+  . (selector (argument_part (arguments)))
 )
 
 ; assignments

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -112,6 +112,10 @@
     (initialized_variable_definition
         name: (identifier) @variable))
 
+(for_statement
+    (for_loop_parts
+        name: (identifier) @variable))
+
 ; properties
 (unconditional_assignable_selector
  (identifier) @property)

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -117,6 +117,11 @@
 (conditional_assignable_selector
  (identifier) @property)
 
+((selector
+  (unconditional_assignable_selector (identifier) @function.method))
+  (selector (argument_part (arguments)))
+)
+
 ; assignments
 (assignment_expression
  left: (assignable_expression) @variable)

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -138,7 +138,7 @@
 ; Parameters
 ; --------------------
 (formal_parameter
- name: (identifier) @variable.parameter)
+ (identifier) @variable.parameter)
 
 (named_argument
  (label

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -83,7 +83,7 @@
 (enum_declaration
  name: (identifier) @type)
 (enum_constant
- name: (identifier) @type)
+ name: (identifier) @property)
 
 ((scoped_identifier
   scope: (identifier) @type

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -108,8 +108,6 @@
 ((identifier) @type
  (#match? @type "^_?[A-Z].*[a-z]"))
 
-("Function" @type)
-
 ; properties
 (unconditional_assignable_selector
  (identifier) @property)
@@ -186,6 +184,7 @@
  "new"
  "super"
  "with"
+ "Function"
  ] @keyword
 
 "return" @keyword.return

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -80,11 +80,6 @@
 (function_signature
  name: (identifier) @function.method)
 
-(getter_signature
- (identifier) @function.method)
-
-(setter_signature
- name: (identifier) @function.method)
 (enum_declaration
  name: (identifier) @type)
 (enum_constant
@@ -122,6 +117,11 @@
 
 (conditional_assignable_selector
  (identifier) @property)
+
+(getter_signature
+ (identifier) @property)
+(setter_signature
+ name: (identifier) @property)
 
 ((selector
   (unconditional_assignable_selector (identifier) @function.method))

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -111,6 +111,10 @@
     (for_loop_parts
         name: (identifier) @variable))
 
+(function_expression
+    body: (function_expression_body
+        (identifier) @variable))
+
 ; properties
 (unconditional_assignable_selector
  (identifier) @property)

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -111,10 +111,6 @@
     (for_loop_parts
         name: (identifier) @variable))
 
-(function_expression
-    body: (function_expression_body
-        (identifier) @variable))
-
 (catch_parameters (identifier) @variable)
 
 ; properties


### PR DESCRIPTION
- Makes `void` a keyword
- Makes `Function` a keyword
- Correctly highlight methods (fixes #5)
- Fix variable declarations not being highlighted.
- Made getters/setters highlighted as properties.