### PR TITLE
Add tasks for tests

### DIFF
--- a/languages/dart/runnables.scm
+++ b/languages/dart/runnables.scm
@@ -43,3 +43,79 @@
         (#set! tag flutter-test-main)
     )
 )
+
+; Dart test file
+(
+    (
+        (import_or_export
+            (library_import
+                (import_specification
+                    ("import"
+                        (configurable_uri
+                            (uri
+                                (string_literal) @_import
+                                (#match? @_import "package:test/test.dart")
+        ))))))
+        (
+            (function_signature
+                name: (_) @run
+            )
+            (#eq? @run "main")
+        )
+        (#set! tag dart-test-file)
+    )
+)
+
+; Dart test group
+(
+    (
+        (import_or_export
+            (library_import
+                (import_specification
+                    ("import"
+                        (configurable_uri
+                            (uri
+                                (string_literal) @_import
+                                (#match? @_import "package:test/test.dart")
+        ))))))
+        (
+            (function_body
+                (block
+                    (expression_statement
+                        (
+                            (identifier) @run (#eq? @run "group")
+        )))))
+        (#set! tag dart-test-group)
+    )
+)
+
+; Dart test single
+(
+    (
+        (import_or_export
+            (library_import
+                (import_specification
+                    ("import"
+                        (configurable_uri
+                            (uri
+                                (string_literal) @_import
+                                (#match? @_import "package:test/test.dart")
+        ))))))
+        (
+            (function_body
+                (block
+                    (expression_statement
+                        (selector
+                            (argument_part
+                                (arguments
+                                    (argument
+                                        (function_expression
+                                            (function_expression_body
+                                                (block
+                                                    (expression_statement
+                                                        (
+                                                            (identifier) @run (#eq? @run "test")
+        )))))))))))))
+        (#set! tag dart-test-single)
+    )
+)

--- a/languages/dart/tasks.json
+++ b/languages/dart/tasks.json
@@ -22,5 +22,23 @@
     "command": "fvm flutter",
     "args": ["test", "$ZED_FILE"],
     "tags": ["flutter-test-main"]
+  },
+  {
+    "label": "dart test file $ZED_STEM",
+    "command": "dart",
+    "args": ["test", "$ZED_FILE"],
+    "tags": ["dart-test-file"]
+  },
+  {
+    "label": "dart test group $ZED_STEM",
+    "command": "dart",
+    "args": ["test", "\"$ZED_FILE?line=$ZED_ROW\""],
+    "tags": ["dart-test-group"]
+  },
+  {
+    "label": "dart test single $ZED_STEM",
+    "command": "dart",
+    "args": ["test", "\"$ZED_FILE?line=$ZED_ROW\""],
+    "tags": ["dart-test-single"]
   }
 ]


### PR DESCRIPTION
This PR create runnable buttons for dart unit tests (non-flutter). It adds buttons for:
* the whole file, on `main` function
* each `group`
* each `test`

RESOLVES: #9