### PR TITLE
Improve syntax highlighting

### DIFF
--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -1,3 +1,4 @@
+(identifier) @variable
 (dotted_identifier_list) @string
 
 ; Methods
@@ -103,16 +104,6 @@
 ((identifier) @type
  (#match? @type "^_?[A-Z].*[a-z]"))
 
-(local_variable_declaration
-    (initialized_variable_definition
-        name: (identifier) @variable))
-
-(for_statement
-    (for_loop_parts
-        name: (identifier) @variable))
-
-(catch_parameters (identifier) @variable)
-
 ; properties
 (unconditional_assignable_selector
  (identifier) @property)
@@ -210,7 +201,7 @@
  "super"
  "with"
  "Function"
- ] @keyword
+ ] @keyword.definition
 
 "return" @keyword.return
 


### PR DESCRIPTION
Identifiers are now generally treated as variables, which is what almost all supported languages do. This allows removing some previous definitions.

Keywords like "late", "class", and "enum" are now classified as `keyword.definition`, allowing for more fine-grained syntax highlighting then before.
