### PR TITLE
Fix for type.qualifier being highlighted as types

### DIFF
--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -249,7 +249,7 @@
  "final"
   "base"
   "sealed"
- ] @type.qualifier
+ ] @keyword.modifier ; could be @type.qualifier
 
 ; when used as an identifier:
 ((identifier) @variable.builtin


### PR DESCRIPTION
Closes: https://github.com/zed-extensions/dart/issues/25

While `@type.qualifier` is commonly sometimes used, none of the built in Zed themes and only one community support it.  As a result it will fallback to being highlighted as `type` just like the adjacent types, which doesn't look right.

Format it as a keyword instead.

| Before | After |
| - | - |
| <img width="386" height="129" alt="Screenshot 2025-08-06 at 11 35 33" src="https://github.com/user-attachments/assets/8ed85ff1-f9d9-4bd1-b7ab-f4abd6dd4daf" /> | <img width="379" height="137" alt="Screenshot 2025-08-06 at 11 35 19" src="https://github.com/user-attachments/assets/6305bfc8-e2cf-40d6-9c81-2c43d78e3c2f" /> |
