### PR TITLE
Dart / Flutter debug adapter enhancements

### DIFF
--- a/debug_adapter_schemas/Dart.json
+++ b/debug_adapter_schemas/Dart.json
@@ -26,6 +26,10 @@
       "type": "string",
       "description": "Path to the working directory"
     },
+    "useFvm": {
+      "type": "boolean",
+      "description": "Weather to use fvm to run the Dart/Flutter program"
+    },
     "args": {
       "type": "array",
       "description": "Arguments passed to the Dart program.",


### PR DESCRIPTION
I have 3 enhancements for the Flutter debug adapter

1. Fixed the lining warning when specifying "Dart" as the `adapter` value (case sensitivity)
2. Added the ability to specify the current working directory (`cwd`) for the debugger
3. Added the ability to specify and use FVM for running dart/flutter apps