### PR TITLE
Disable angle bracket auto-closing

### DIFF
--- a/languages/dart/config.toml
+++ b/languages/dart/config.toml
@@ -7,7 +7,7 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
-    { start = "<", end = ">", close = true, newline = false},
+    { start = "<", end = ">", close = false, newline = false},
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },


### PR DESCRIPTION
Disables auto-closing for angle brackets < and >.

This prevents the behavior where typing `a < b` results in `a <b>`. This matches the behavior in other C-style language extensions (e.g., Java).

Closes #51