### PR TITLE
feat: add dart-main tag and fix flutter test/group button priority

### DIFF
--- a/languages/dart/runnables.scm
+++ b/languages/dart/runnables.scm
@@ -1,3 +1,11 @@
+; Dart main — fallback for standalone Dart files.
+; Must be first so that more specific patterns below (Flutter, test)
+; take priority via Zed's "last target wins" behavior on the same row.
+((function_signature
+  name: (_) @run)
+  (#eq? @run "main")
+  (#set! tag dart-main))
+
 ; Flutter main
 ((import_or_export
   (library_import

--- a/languages/dart/runnables.scm
+++ b/languages/dart/runnables.scm
@@ -1,80 +1,117 @@
-; Dart main — fallback for standalone Dart files.
-; Must be first so that more specific patterns below (Flutter, test)
-; take priority via Zed's "last target wins" behavior on the same row.
-((function_signature
-  name: (_) @run)
-  (#eq? @run "main")
-  (#set! tag dart-main))
-
-; Flutter main
-((import_or_export
-  (library_import
-    (import_specification
-      ("import"
+; Dart main — matches dart: SDK imports.
+; Since `dart format` places dart: imports first, the @_import capture
+; position will be earlier than flutter/test imports, so specific patterns
+; (flutter-main, flutter-test-main, etc.) overwrite this when they match.
+(program
+  (import_or_export
+    (library_import
+      (import_specification
         (configurable_uri
           (uri
             (string_literal) @_import
-            (#match? @_import "package:flutter/(material|widgets|cupertino).dart")
-            (#not-match? @_import "package:flutter_test/flutter_test.dart")
-            (#not-match? @_import "package:test/test.dart")))))))
-  ((function_signature
-    name: (_) @run)
+            (#match? @_import "^\"dart:"))))))
+  (function_signature
+    name: (_) @run
+    (#eq? @run "main"))
+  (#set! tag dart-main))
+
+; Dart main for parse errors (ERROR root).
+(ERROR
+  (import_or_export
+    (library_import
+      (import_specification
+        (configurable_uri
+          (uri
+            (string_literal) @_import
+            (#match? @_import "^\"dart:"))))))
+  (function_signature
+    name: (_) @run
+    (#eq? @run "main"))
+  (#set! tag dart-main))
+
+; Flutter main
+(program
+  (import_or_export
+    (library_import
+      (import_specification
+        (configurable_uri
+          (uri
+            (string_literal) @_import
+            (#match? @_import "package:flutter/(material|widgets|cupertino).dart"))))))
+  (function_signature
+    name: (_) @run
+    (#eq? @run "main"))
+  (#set! tag flutter-main))
+
+; Flutter main (parse error fallback)
+(ERROR
+  (import_or_export
+    (library_import
+      (import_specification
+        (configurable_uri
+          (uri
+            (string_literal) @_import
+            (#match? @_import "package:flutter/(material|widgets|cupertino).dart"))))))
+  (function_signature
+    name: (_) @run
     (#eq? @run "main"))
   (#set! tag flutter-main))
 
 ; Flutter test main
-((import_or_export
-  (library_import
-    (import_specification
-      ("import"
+(program
+  (import_or_export
+    (library_import
+      (import_specification
         (configurable_uri
           (uri
             (string_literal) @_import
-            (#match? @_import "package:flutter_test/flutter_test.dart")))))))
-  ((function_signature
-    name: (_) @run)
+            (#match? @_import "package:flutter_test/flutter_test.dart"))))))
+  (function_signature
+    name: (_) @run
     (#eq? @run "main"))
   (#set! tag flutter-test-main))
 
-; Dart test file
-((import_or_export
-  (library_import
-    (import_specification
-      ("import"
+; Flutter test main (parse error fallback)
+(ERROR
+  (import_or_export
+    (library_import
+      (import_specification
         (configurable_uri
           (uri
             (string_literal) @_import
-            (#match? @_import "package:test/test.dart")))))))
-  ((function_signature
-    name: (_) @run)
+            (#match? @_import "package:flutter_test/flutter_test.dart"))))))
+  (function_signature
+    name: (_) @run
     (#eq? @run "main"))
-  (#set! tag dart-test-file))
+  (#set! tag flutter-test-main))
 
-; Dart test group
-((import_or_export
-  (library_import
-    (import_specification
-      ("import"
+; Flutter test group (block body: void main() { group(...) })
+; Arrow-body variant removed: when main() => group(...), both identifiers
+; share the same line, causing group to overwrite the more useful test-main tag.
+(program
+  (import_or_export
+    (library_import
+      (import_specification
         (configurable_uri
           (uri
             (string_literal) @_import
-            (#match? @_import "package:test/test.dart")))))))
+            (#match? @_import "package:flutter_test/flutter_test.dart"))))))
   (function_body
     (block
       (expression_statement
         ((identifier) @run
           (#eq? @run "group")))))
-  (#set! tag dart-test-group))
+  (#set! tag flutter-test-group))
 
-; Dart test single
-((import_or_export
-  (library_import
-    (import_specification
-      ("import"
+; Flutter test single (block body)
+(program
+  (import_or_export
+    (library_import
+      (import_specification
         (configurable_uri
           (uri
             (string_literal) @_import
-            (#match? @_import "package:test/test.dart")))))))
+            (#match? @_import "package:flutter_test/flutter_test.dart"))))))
   (function_body
     (block
       (expression_statement
@@ -88,4 +125,103 @@
                       (expression_statement
                         ((identifier) @run
                           (#eq? @run "test")))))))))))))
+  (#set! tag flutter-test-single))
+
+; Flutter test single (arrow body: void main() => group("name", () { test(...) }))
+(program
+  (import_or_export
+    (library_import
+      (import_specification
+        (configurable_uri
+          (uri
+            (string_literal) @_import
+            (#match? @_import "package:flutter_test/flutter_test.dart"))))))
+  (function_body
+    (selector
+      (argument_part
+        (arguments
+          (argument
+            (function_expression
+              (function_expression_body
+                (block
+                  (expression_statement
+                    ((identifier) @run
+                      (#eq? @run "test")))))))))))
+  (#set! tag flutter-test-single))
+
+; Dart test file
+(program
+  (import_or_export
+    (library_import
+      (import_specification
+        (configurable_uri
+          (uri
+            (string_literal) @_import
+            (#match? @_import "package:test/test.dart"))))))
+  (function_signature
+    name: (_) @run
+    (#eq? @run "main"))
+  (#set! tag dart-test-file))
+
+; Dart test group (block body: void main() { group(...) })
+; Arrow-body variant removed: same reason as flutter-test-group.
+(program
+  (import_or_export
+    (library_import
+      (import_specification
+        (configurable_uri
+          (uri
+            (string_literal) @_import
+            (#match? @_import "package:test/test.dart"))))))
+  (function_body
+    (block
+      (expression_statement
+        ((identifier) @run
+          (#eq? @run "group")))))
+  (#set! tag dart-test-group))
+
+; Dart test single (block body)
+(program
+  (import_or_export
+    (library_import
+      (import_specification
+        (configurable_uri
+          (uri
+            (string_literal) @_import
+            (#match? @_import "package:test/test.dart"))))))
+  (function_body
+    (block
+      (expression_statement
+        (selector
+          (argument_part
+            (arguments
+              (argument
+                (function_expression
+                  (function_expression_body
+                    (block
+                      (expression_statement
+                        ((identifier) @run
+                          (#eq? @run "test")))))))))))))
+  (#set! tag dart-test-single))
+
+; Dart test single (arrow body)
+(program
+  (import_or_export
+    (library_import
+      (import_specification
+        (configurable_uri
+          (uri
+            (string_literal) @_import
+            (#match? @_import "package:test/test.dart"))))))
+  (function_body
+    (selector
+      (argument_part
+        (arguments
+          (argument
+            (function_expression
+              (function_expression_body
+                (block
+                  (expression_statement
+                    ((identifier) @run
+                      (#eq? @run "test")))))))))))
   (#set! tag dart-test-single))

--- a/languages/dart/tasks.json
+++ b/languages/dart/tasks.json
@@ -1,5 +1,11 @@
 [
   {
+    "label": "dart run $ZED_STEM",
+    "command": "dart",
+    "args": ["run", "$ZED_FILE"],
+    "tags": ["dart-main"]
+  },
+  {
     "label": "flutter run",
     "command": "flutter",
     "args": ["run"],

--- a/languages/dart/tasks.json
+++ b/languages/dart/tasks.json
@@ -30,6 +30,30 @@
     "tags": ["flutter-test-main"]
   },
   {
+    "label": "flutter test group $ZED_STEM",
+    "command": "flutter",
+    "args": ["test", "\"$ZED_FILE?line=$ZED_ROW\""],
+    "tags": ["flutter-test-group"]
+  },
+  {
+    "label": "fvm flutter test group $ZED_STEM",
+    "command": "fvm flutter",
+    "args": ["test", "\"$ZED_FILE?line=$ZED_ROW\""],
+    "tags": ["flutter-test-group"]
+  },
+  {
+    "label": "flutter test single $ZED_STEM",
+    "command": "flutter",
+    "args": ["test", "\"$ZED_FILE?line=$ZED_ROW\""],
+    "tags": ["flutter-test-single"]
+  },
+  {
+    "label": "fvm flutter test single $ZED_STEM",
+    "command": "fvm flutter",
+    "args": ["test", "\"$ZED_FILE?line=$ZED_ROW\""],
+    "tags": ["flutter-test-single"]
+  },
+  {
     "label": "dart test file $ZED_STEM",
     "command": "dart",
     "args": ["test", "$ZED_FILE"],


### PR DESCRIPTION
Hi Team!

This PR introduces `dart run` [support for standalone Dart files](https://github.com/zed-extensions/dart/issues/53) and fixes several issues with Flutter test/group play buttons in the gutter.

## Changes

### `dart-main` — new tag for `dart run`
- Matches `main()` functions in files with `dart:` SDK imports
- Uses the same pattern structure as `flutter-main` so tree-sitter returns it with the same step count — since `dart format` places `dart:` imports before `package:` imports, `dart-main` is always processed first and overwritten by more specific tags in Flutter/test files.

### `ERROR` root fallback variants
- Added `(ERROR ...)` variants for `dart-main`, `flutter-main`, and `flutter-test-main`.
- Files using Dart 3 shorthand constructors (e.g. `.all(.circular(4))`) parse as `ERROR` root instead of `program` — without these fallbacks, those files get no play buttons at all.

### Arrow-body test fixes
- **Removed** arrow-body `group` patterns (`flutter-test-group`, `dart-test-group`) — when `void main() => group(...)`, both `main` and `group` identifiers share the same row, so `group` overwrites the more useful `test-main` tag.
- **Added** arrow-body `test-single` patterns — `test()` calls inside `main() => group("name", () { test(...) })` are on separate rows, so they work correctly.

### Cleanup
- Removed redundant `#not-match?` predicates on `flutter-main` (a string matching `package:flutter/material.dart` can never also match `flutter_test` or `test`).
- Wrapped all patterns in explicit `(program ...)` / `(ERROR ...)` root nodes.

## Known limitations

- **`dart-main` only matches files with `dart:` imports** (e.g. `dart:io`, `dart:convert`). Pure Dart files importing only `package:` dependencies won't get a play button. This is unavoidable: patterns matching non-`dart:` imports have later capture positions than flutter imports, so they'd overwrite `flutter-main` in Zed's HashMap. Most real CLI tools use `dart:` imports, so this is a narrow edge case.
- **Tree-sitter step-count ordering** means a simple fallback pattern (without import matching) always has the fewest steps, is returned last by `QueryMatches`, and overwrites all specific tags — making a universal `dart-main` impossible without changes to Zed's runnable resolution logic.

## A note on testing

This extension currently has no test infrastructure for verifying runnables behavior. The tree-sitter CLI (`tree-sitter query`) confirms pattern matching and ordering, but **Zed's WASM runtime can behave differently** — I observed cases where CLI results were correct, but Zed didn't render the expected play button. Introducing a test harness that validates runnables against Zed's actual `SyntaxMapMatches` ordering would prevent regressions and remove the guesswork from future changes.

## Verification

Tested with `tree-sitter query` against grammar revision `80e23c0`:

| File type | Expected tag | Result |
|-----------|-------------|--------|
| Standalone Dart (`dart:io` import) | `dart-main` | ✅ |
| Flutter app (`package:flutter/material.dart`) | `flutter-main` | ✅ |
| Flutter test (block body `main() { group() }`) | `flutter-test-main` + `flutter-test-group` | ✅ |
| Flutter test (arrow body `main() => group()`) | `flutter-test-main` + `flutter-test-single` per test | ✅ |
| Dart test (`package:test/test.dart`) | `dart-test-file` | ✅ |
| ERROR root Flutter app (Dart 3 shorthand) | `flutter-main` | ✅ |