### PR TITLE
Fix `@` symbol highlighting in Dart annotations

### DIFF
--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -17,11 +17,6 @@
     .
     (argument_part))) @function
 
-; Annotations
-; --------------------
-(annotation
-  name: (identifier) @attribute)
-
 ; Operators and Tokens
 ; --------------------
 (template_substitution
@@ -36,7 +31,6 @@
 (escape_sequence) @string.escape
 
 [
-  "@"
   "=>"
   ".."
   "??"
@@ -113,6 +107,12 @@
 
 ((identifier) @type
   (#match? @type "^_?[A-Z].*[a-z]"))
+
+; Annotations
+; --------------------
+(annotation
+  "@" @attribute
+  name: (identifier) @attribute)
 
 ; properties
 (unconditional_assignable_selector


### PR DESCRIPTION
Hey Team!

Reference to (part of) the Issue: https://github.com/zed-extensions/dart/issues/29#:~:text=override

- The `@` symbol in annotations (e.g. `@override`, `@Deprecated()`) was highlighted as an operator while the annotation name received `@attribute` styling, making them appear as two visually distinct tokens
- Capture `@` as `@attribute` inside the annotation rule and remove it from the operators block
- Reorder annotation rules after the generic uppercase `@type` pattern so that `@attribute` takes final precedence for names like `Deprecated`

## Before:
<img width="1037" height="748" alt="Screenshot 2026-03-22 at 22 49 29" src="https://github.com/user-attachments/assets/b9976dd9-94af-42fe-a634-4805931c950f" />

## After:
<img width="1037" height="748" alt="image" src="https://github.com/user-attachments/assets/86ca6995-1d12-4c6d-b725-f080dab01dac" />
