### PR TITLE
Forward `preferred_line_length` to Dart LSP as `dart.lineLength`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,16 +752,15 @@ dependencies = [
 
 [[package]]
 name = "zed_dart"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "zed_extension_api",
 ]
 
 [[package]]
 name = "zed_extension_api"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
+version = "0.8.0"
+source = "git+https://github.com/zed-industries/zed?rev=103fa371562e86af63204df8cf7bf35559ada0d4#103fa371562e86af63204df8cf7bf35559ada0d4"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "zed_dart"
-version = "0.4.0"
+version = "0.3.6"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_dart"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2021"
 publish = false
 license = "Apache-2.0"
@@ -10,4 +10,4 @@ path = "src/dart.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.7.0"
+zed_extension_api = { git = "https://github.com/zed-industries/zed", rev = "103fa371562e86af63204df8cf7bf35559ada0d4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_dart"
-version = "0.4.0"
+version = "0.3.6"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "dart"
 name = "Dart"
 description = "Dart support."
-version = "0.4.0"
+version = "0.3.6"
 schema_version = 1
 authors = [
     "Abdullah Alsigar <abdullah.alsigar@gmail.com>",

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "dart"
 name = "Dart"
 description = "Dart support."
-version = "0.3.5"
+version = "0.4.0"
 schema_version = 1
 authors = [
     "Abdullah Alsigar <abdullah.alsigar@gmail.com>",

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -1,5 +1,5 @@
 use zed::lsp::CompletionKind;
-use zed::settings::LspSettings;
+use zed::settings::{LanguageSettings, LspSettings};
 use zed::{CodeLabel, CodeLabelSpan};
 use zed_extension_api::serde_json::json;
 use zed_extension_api::{
@@ -207,14 +207,25 @@ impl zed::Extension for DartExtension {
         _language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<Option<serde_json::Value>> {
-        let settings = LspSettings::for_worktree("dart", worktree)
+        let mut dart_settings = serde_json::Map::new();
+
+        if let Ok(language_settings) = LanguageSettings::for_worktree(Some("Dart"), worktree) {
+            dart_settings.insert(
+                "lineLength".into(),
+                language_settings.preferred_line_length.into(),
+            );
+        }
+
+        let user_settings = LspSettings::for_worktree("dart", worktree)
             .ok()
             .and_then(|lsp_settings| lsp_settings.settings.clone())
             .unwrap_or_default();
 
-        Ok(Some(serde_json::json!({
-            "dart": settings
-        })))
+        if let serde_json::Value::Object(user_map) = user_settings {
+            dart_settings.extend(user_map);
+        }
+
+        Ok(Some(serde_json::json!({ "dart": dart_settings })))
     }
 
     fn label_for_completion(


### PR DESCRIPTION
**Blocked** by unreleased `zed_extension_api` v0.8.0
**Related** Zed [PR](https://github.com/zed-industries/zed/pull/52175)
**Closes** #2

## Context

Now that `preferred_line_length` is exposed in the Extension API's
`LanguageSettings` (merged in zed-industries/zed#52175), the Dart
extension can forward it to the Dart Analysis Server as `dart.lineLength`
via `workspace/configuration`.

This means users no longer need to manually configure
`lsp.dart.settings.lineLength` — the Dart formatter will automatically
respect the `preferred_line_length` set in Zed settings.

Explicit `lsp.dart.settings` overrides still take precedence.

## Changes

- Bumped `zed_extension_api` to `0.8.0` (git dep until crate is published)
- Read `preferred_line_length` from `LanguageSettings` with graceful
  fallback if unavailable
- Forward it as `dart.lineLength` in workspace configuration
- Merge with existing user LSP settings (user overrides win)
- Bumped extension version to `0.4.0`