### PR TITLE
Highlight `case` keyword in if-case expressions

### DIFF
--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -290,6 +290,7 @@
   "else"
   "switch"
   "default"
+  "case"
 ] @keyword.conditional
 
 [


### PR DESCRIPTION
The tree-sitter grammar parses `case` in if-case patterns (e.g., `if (x case String value)`) as an anonymous `"case"` node, unlike switch statements which use the named `case_builtin` node. This meant `case` was unhighlighted in if-case expressions.

Add `"case"` to the `@keyword.conditional` group alongside `if`, `else`, `switch`, and `default`.

Fixes part of #29 

<img width="428" height="145" alt="image" src="https://github.com/user-attachments/assets/c22cca5e-491f-489d-a2cc-24ce8e681d26" />
