### PR TITLE
Add support for dot shorthands

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -18,7 +18,7 @@ languages = ["Dart"]
 
 [grammars.dart]
 repository = "https://github.com/UserNobody14/tree-sitter-dart"
-commit = "0fc19c3a57b1109802af41d2b8f60d8835c5da3a"
+commit = "6922ad29141e819773d6ffb0c6d2c27adefb5acc"
 
 [debug_adapters.Dart]
 # Optional relative path to the JSON schema for the debug adapter configuration schema. Defaults to `debug_adapter_schemas/$DEBUG_ADAPTER_NAME_ID.json`.

--- a/extension.toml
+++ b/extension.toml
@@ -18,7 +18,7 @@ languages = ["Dart"]
 
 [grammars.dart]
 repository = "https://github.com/UserNobody14/tree-sitter-dart"
-commit = "80e23c07b64494f7e21090bb3450223ef0b192f4"
+commit = "0fc19c3a57b1109802af41d2b8f60d8835c5da3a"
 
 [debug_adapters.Dart]
 # Optional relative path to the JSON schema for the debug adapter configuration schema. Defaults to `debug_adapter_schemas/$DEBUG_ADAPTER_NAME_ID.json`.

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -153,6 +153,16 @@
   (argument_part
     (arguments)))
 
+; Dot shorthand
+(dot_shorthand
+    (identifier) @property)
+((dot_shorthand
+    (identifier) @function.method)
+    .
+    (selector
+        (argument_part
+            (arguments))))
+
 ; Some methods do not have a selector as a parent of the conditional_assignable_selector
 ; For example, super methods.
 ((unconditional_assignable_selector
@@ -271,7 +281,6 @@
   (final_builtin)
   "abstract"
   "covariant"
-  "dynamic"
   "external"
   "static"
   "final"

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -164,6 +164,11 @@
     (argument_part
       (arguments))))
 
+((dot_shorthand
+  (identifier) @function.method)
+  .
+  (arguments))
+
 ; Some methods do not have a selector as a parent of the conditional_assignable_selector
 ; For example, super methods.
 ((unconditional_assignable_selector

--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -155,13 +155,14 @@
 
 ; Dot shorthand
 (dot_shorthand
-    (identifier) @property)
+  (identifier) @property)
+
 ((dot_shorthand
-    (identifier) @function.method)
-    .
-    (selector
-        (argument_part
-            (arguments))))
+  (identifier) @function.method)
+  .
+  (selector
+    (argument_part
+      (arguments))))
 
 ; Some methods do not have a selector as a parent of the conditional_assignable_selector
 ; For example, super methods.


### PR DESCRIPTION
Updates `tree-sitter-dart` for the grammar and adds highlighting.

It seems there is still some errors present in the syntax tree, mainly when using a dot shorthand with the const keyword (ex. `const .function()`) but this will have to be fixed in https://github.com/UserNobody14/tree-sitter-dart

Before:
<img width="650" height="174" alt="Screenshot from 2026-04-22 08-35-23" src="https://github.com/user-attachments/assets/e7733cf4-5b50-403c-8bcf-13b98130a70e" />
After:
<img width="650" height="174" alt="Screenshot from 2026-04-22 08-34-47" src="https://github.com/user-attachments/assets/359cc006-71f4-4d71-8f1e-f27312f38fd9" />

```dart
void main() {
  final MyClass myClass = .new("");
  final MyClass myClass2 = .named("");
  const MyEnum myEnum = .one;
}

class MyClass {
  final String field;

  MyClass(this.field);
  MyClass.named(this.field);
}

enum MyEnum { one, two }
```
