### PR TITLE
Add Flutter emulator tasks

### DIFF
--- a/languages/dart/tasks.json
+++ b/languages/dart/tasks.json
@@ -12,6 +12,16 @@
     "tags": ["flutter-main"]
   },
   {
+    "label": "flutter emulators",
+    "command": "flutter",
+    "args": ["emulators"]
+  },
+  {
+    "label": "flutter emulators launch apple_ios_simulator",
+    "command": "flutter",
+    "args": ["emulators", "--launch", "apple_ios_simulator"]
+  },
+  {
     "label": "flutter test $ZED_STEM",
     "command": "flutter",
     "args": ["test", "$ZED_FILE"],


### PR DESCRIPTION
## Summary

- Add a task template for listing Flutter emulators
- Add a task template for launching the default iOS simulator via `apple_ios_simulator`

Android emulator launch tasks are not included because Android emulator IDs are user-specific.

## Verification

- `jq empty languages/dart/tasks.json`
- `cargo fmt -- --check`
- `cargo check`
- `cargo build --target wasm32-wasip1 --release`
- `git diff --check`