### PR TITLE
feat: add syntax highlighting for Dart 3 features

### DIFF
--- a/languages/dart/highlights.scm
+++ b/languages/dart/highlights.scm
@@ -184,6 +184,11 @@
   (label
     (identifier) @variable.parameter))
 
+; Record fields
+(record_field
+  (label
+    (identifier) @property))
+
 ; Literals
 ; --------------------
 [
@@ -269,6 +274,10 @@
 [
   (const_builtin)
   (final_builtin)
+  (sealed)
+  (base)
+  (interface)
+  (mixin)
   "abstract"
   "covariant"
   "dynamic"
@@ -291,6 +300,7 @@
   "switch"
   "default"
   "case"
+  "when"
 ] @keyword.conditional
 
 [


### PR DESCRIPTION
- Add `sealed`, `base`, `interface`, and `mixin` to `@keyword.modifier`

- Add `when` to `@keyword.conditional` for switch expressions

- Add `record_field` labels to highlight as `@property`
