### PR TITLE
Fix DAP binary resolution for remote worktrees

### DIFF
--- a/src/dart.rs
+++ b/src/dart.rs
@@ -107,12 +107,15 @@ impl zed::Extension for DartExtension {
         };
 
         let (command, arguments) = if use_fvm {
-            (
-                "fvm".to_string(),
-                vec![tool.to_string(), "debug_adapter".to_string()],
-            )
+            let fvm_path = worktree
+                .which("fvm")
+                .ok_or_else(|| "fvm not found in PATH. Install fvm or set useFvm to false.".to_string())?;
+            (fvm_path, vec![tool.to_string(), "debug_adapter".to_string()])
         } else {
-            (tool.to_string(), vec!["debug_adapter".to_string()])
+            let tool_path = worktree
+                .which(tool)
+                .ok_or_else(|| format!("{tool} not found in PATH. Install from dart.dev or flutter.dev."))?;
+            (tool_path, vec!["debug_adapter".to_string()])
         };
 
         let device_id = user_config

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -107,14 +107,17 @@ impl zed::Extension for DartExtension {
         };
 
         let (command, arguments) = if use_fvm {
-            let fvm_path = worktree
-                .which("fvm")
-                .ok_or_else(|| "fvm not found in PATH. Install fvm or set useFvm to false.".to_string())?;
-            (fvm_path, vec![tool.to_string(), "debug_adapter".to_string()])
+            let fvm_path = worktree.which("fvm").ok_or_else(|| {
+                "fvm not found in PATH. Install fvm or set useFvm to false.".to_string()
+            })?;
+            (
+                fvm_path,
+                vec![tool.to_string(), "debug_adapter".to_string()],
+            )
         } else {
-            let tool_path = worktree
-                .which(tool)
-                .ok_or_else(|| format!("{tool} not found in PATH. Install from dart.dev or flutter.dev."))?;
+            let tool_path = worktree.which(tool).ok_or_else(|| {
+                format!("{tool} not found in PATH. Install from dart.dev or flutter.dev.")
+            })?;
             (tool_path, vec!["debug_adapter".to_string()])
         };
 


### PR DESCRIPTION
## Problem
`get_dap_binary` passed raw binary names (`"flutter"`, `"dart"`, `"fvm"`) 
as commands without resolving them against the host's PATH. WASM extensions 
cannot read `$PATH` directly, so the debug adapter failed to launch on remote 
(SSH) worktrees.
## Fix
Resolve binary paths using `worktree.which()`, which works correctly on both 
local and remote worktrees. This is consistent with how `language_server_binary` 
already resolves the `dart` binary.
## Related Issues

- zed-extensions/dart#93