### PR TITLE
Add testMode config to debug tests via the DAP --test flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ Add the following to your `settings.json` to enable features like organizing imp
 }
 ```
 
+### Debugging tests (`.zed/debug.json`)
+
+Set `"testMode": true` in a debug configuration to run the target file as a test
+suite. The extension spawns the debug adapter with `--test`, so the program runs
+via `flutter test` / `dart test` (headless) instead of `flutter run` / `dart run`.
+Breakpoints, stepping, and variable inspection work as usual.
+
+```json
+{
+  "label": "Debug current test file",
+  "adapter": "Dart",
+  "type": "flutter",
+  "request": "launch",
+  "program": "$ZED_FILE",
+  "cwd": "$ZED_DIRNAME",
+  "testMode": true,
+  "useFvm": true
+}
+```
+
+Zed task variables such as `$ZED_FILE` and `$ZED_DIRNAME` work in `.zed/debug.json`.
+Use `"toolArgs"` to narrow the run, e.g. `"toolArgs": ["--plain-name", "<test name>"]`.
+For a pure-Dart package, set `"type": "dart"` instead (`dart debug_adapter --test`).
+
 ## Documentation
 
 See:

--- a/debug_adapter_schemas/Dart.json
+++ b/debug_adapter_schemas/Dart.json
@@ -43,6 +43,11 @@
       "type": "boolean",
       "description": "Whether to use fvm to run the Dart/Flutter program"
     },
+    "testMode": {
+      "type": "boolean",
+      "description": "Run the program as a test suite (spawns the debug adapter with --test, i.e. flutter test / dart test instead of flutter run / dart run).",
+      "default": false
+    },
     "args": {
       "type": "array",
       "description": "Arguments passed to the Dart program.",
@@ -71,8 +76,7 @@
       "enum": [
         "debug",
         "profile",
-        "release",
-        "test"
+        "release"
       ],
       "description": "The Flutter mode to use.",
       "default": "debug"

--- a/src/dart.rs
+++ b/src/dart.rs
@@ -96,6 +96,11 @@ impl zed::Extension for DartExtension {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
+        let test_mode = user_config
+            .get("testMode")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         // Get debug_mode from user config (flutter or dart)
         let debug_mode = user_config
             .get("type")
@@ -106,12 +111,17 @@ impl zed::Extension for DartExtension {
         let tool = tool_binary(debug_mode);
 
         let (command, arguments) = if use_fvm {
-            (
-                "fvm".to_string(),
-                vec![tool.to_string(), "debug_adapter".to_string()],
-            )
+            let mut args = vec![tool.to_string(), "debug_adapter".to_string()];
+            if test_mode {
+                args.push("--test".to_string());
+            }
+            ("fvm".to_string(), args)
         } else {
-            (tool.to_string(), vec!["debug_adapter".to_string()])
+            let mut args = vec!["debug_adapter".to_string()];
+            if test_mode {
+                args.push("--test".to_string());
+            }
+            (tool.to_string(), args)
         };
 
         let device_id = user_config.get("deviceId").and_then(|v| v.as_str());
@@ -160,7 +170,7 @@ impl zed::Extension for DartExtension {
         // which is the only path the DAP actually honors. Only inject when the
         // user set `deviceId` explicitly and did not already pass a device via
         // `toolArgs` — otherwise leave selection to Flutter's auto-pick.
-        if debug_mode == "flutter" {
+        if debug_mode == "flutter" && !test_mode {
             if let Some(id) = device_id {
                 let has_device_arg = tool_args
                     .iter()


### PR DESCRIPTION
## What

Adds an optional boolean `testMode` to the debug configuration. When `true`, the extension spawns the debug adapter with the `--test` flag (`[fvm] flutter|dart debug_adapter --test`), so `program` runs via `flutter test` / `dart test` instead of `flutter run` / `dart run`. Works for both `"type": "flutter"` and `"type": "dart"`. Default `false` — existing configs are unaffected.

```json
{
  "label": "Debug current test file",
  "adapter": "Dart",
  "type": "flutter",
  "request": "launch",
  "program": "$ZED_FILE",
  "cwd": "$ZED_DIRNAME",
  "testMode": true
}
```

## Why

There was previously no way to debug a test the way it actually executes under `flutter test` (headless `flutter_tester`, `AutomatedTestWidgetsFlutterBinding`, goldens, …). The only workaround was `flutter test --start-paused` plus a manual attach with a freshly pasted `vmServiceUri` on every run. The Dart/Flutter SDKs ship this as a mode of the same adapter — see the [Flutter DAP README](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/debug_adapters/README.md) (`--[no-]test`); the extension just never exposed it.

## Changes

- `src/dart.rs` — read `testMode`; append `--test` to the adapter arguments; skip the `deviceId → toolArgs -d <id>` injection in test mode (`flutter test` runs headless — device selection is a `flutter run` concept, and users who need `-d` for integration tests can still pass it via `toolArgs`).
- `debug_adapter_schemas/Dart.json` — declare `testMode` (schema has `additionalProperties: false`); remove the dead `"test"` value from the `flutterMode` enum — the DAP treats `flutterMode` as a build mode (debug/profile/release), so `"test"` never did anything and would now be mistaken for this switch.
- `README.md` — "Debugging tests" section with the config above.

In test mode `toolArgs` keep their existing meaning — the DAP forwards them to `flutter test` / `dart test` (e.g. `--plain-name`, `--tags`).

## Tested

- `flutter` + `testMode: true` on a widget test: headless `flutter test` run, breakpoints/stepping/variables work; `toolArgs: ["--plain-name", …]` narrows to a single test.
- Regression: existing `flutter run` launch and attach configs behave unchanged with `testMode` unset.